### PR TITLE
Fix issue by wrapping in a scope

### DIFF
--- a/RuntimeReloadExample/Program.cs
+++ b/RuntimeReloadExample/Program.cs
@@ -15,16 +15,20 @@ namespace RuntimeReloadExample
 
             while (true)
             {
-                var service = serviceProvider.GetService<IMyService>();
-                var reply = service.DoSomething();
+                using (var scope = serviceProvider.CreateScope())
+                {
+                    var service = scope.ServiceProvider.GetService<IMyService>();
+                    var reply = service.DoSomething();
 
-                Console.WriteLine(reply);
+                    Console.WriteLine(reply);
 
-                Console.WriteLine("Press enter to exit, any other key to repeat...");
+                    Console.WriteLine("Press enter to exit, any other key to repeat...");
 
-                ConsoleKeyInfo keyInfo = Console.ReadKey();
-                if (keyInfo.Key == ConsoleKey.Enter)
-                    break;
+                    ConsoleKeyInfo keyInfo = Console.ReadKey();
+                    if (keyInfo.Key == ConsoleKey.Enter)
+                        break;
+                }
+
             }
         }
     }


### PR DESCRIPTION
Wrap the service calls in a scope to ensure `IOptionsSnapshot` reloads correctly, as described in https://stackoverflow.com/questions/45064140/how-to-reload-appsettings-json-at-runtime-each-time-it-changes-in-net-core-1-1/45091290#45091290